### PR TITLE
feat: adding secrets-manager access poilcy with SecretsReader role

### DIFF
--- a/create_trusted_profile_cross_account/create_trusted_profile_cross_account.py
+++ b/create_trusted_profile_cross_account/create_trusted_profile_cross_account.py
@@ -64,6 +64,7 @@ class CreateTrustedProfileAndCrossAccount(object):
                 iam_configreader_role = iam_policy_management_v1.PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:ConfigReader')
                 iam_service_role_reader = iam_policy_management_v1.PolicyRole(role_id='crn:v1:bluemix:public:iam::::serviceRole:Reader')
                 iam_admin_role = iam_policy_management_v1.PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Administrator')
+                secrets_manager_role = iam_policy_management_v1.PolicyRole(role_id='crn:v1:bluemix:public:secrets-manager::::serviceRole:SecretsReader')
                 policy_roles = [
                                 iam_service_role_reader,
                                 iam_viewer_role,
@@ -88,6 +89,13 @@ class CreateTrustedProfileAndCrossAccount(object):
 
                 policy_roles = [iam_viewer_role,iam_configreader_role]
                 service_name_resource_attribute = iam_policy_management_v1.ResourceAttribute(name='serviceType', value='platform_service')
+                policy_resources = iam_policy_management_v1.PolicyResource(attributes=[account_id_resource_attribute, service_name_resource_attribute])
+                self.policy_service_client.create_policy(
+                type='access', subjects=[policy_subjects], roles=policy_roles, resources=[policy_resources]
+                ).get_result()
+                
+                policy_roles = [secrets_manager_role]
+                service_name_resource_attribute = iam_policy_management_v1.ResourceAttribute(name='serviceName', value='secrets-manager')
                 policy_resources = iam_policy_management_v1.PolicyResource(attributes=[account_id_resource_attribute, service_name_resource_attribute])
                 self.policy_service_client.create_policy(
                 type='access', subjects=[policy_subjects], roles=policy_roles, resources=[policy_resources]


### PR DESCRIPTION
For: https://github.ibm.com/project-fortress/pm/issues/15880

To grant SCC access to the customer's secret manager, the trusted profile must be assigned a policy for the secret manager service with the SecretsReader role.

<img width="1287" alt="image" src="https://github.com/IBM/security-compliance-automation/assets/16933153/85eaba4f-e361-423d-ae29-f47ceed03c57">

<img width="1727" alt="image" src="https://github.com/IBM/security-compliance-automation/assets/16933153/e495923c-a032-4258-9daa-213940033555">

<img width="1706" alt="image" src="https://github.com/IBM/security-compliance-automation/assets/16933153/85d33de8-7e6d-45cc-a551-33e1a533dcbe">
